### PR TITLE
added PERSPECTIVE_API_KEY field in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ LOG_LEVEL=debug
 
 # Go to https://smee.io/new set this to the URL that you are redirected to.
 # WEBHOOK_PROXY_URL=
+PERSPECTIVE_API_KEY=


### PR DESCRIPTION
Since `.env` file has `PERSPECTIVE_API_KEY` field, `.env.example` should also have it