### PR TITLE
create discussion issue if user hostile which fixes #16

### DIFF
--- a/lib/backgroundFinder.js
+++ b/lib/backgroundFinder.js
@@ -1,12 +1,22 @@
-module.exports = ({ dependencies: { extractRepoDetails, getUserCommentedIssues, getCommentsOnIssue, sentimentAnalyser } }) => {
+module.exports = ({ dependencies: { extractRepoDetails, getUserDiscussionIssue, getUserCommentedIssues, getCommentsOnIssue, sentimentAnalyser, createDiscussionIssue } }) => {
   const backgroundFinder = async(context) => {
+    const owner = context.payload.repository.owner.login
     const username = context.payload.comment.user.login
-    console.log('username', username)
+    context.log(`Analyis for ${username} has started`)
+
+    /* -- Check if user is already found hostile -- */
+    const userIssueResult = await getUserDiscussionIssue(context, { owner, username })
+    const alreadyFoundHostile = userIssueResult.data.total_count >= 1
+    if(alreadyFoundHostile) return
+    /* ^- -^ */
+
+    context.log(`${username} has not been found hostile before`)
     const issuesResult = await getUserCommentedIssues(context, { username })
     const { data: { total_count, items: issues } } = issuesResult
     let total_user_comments = 0
 
     for (issue of issues) {
+      // for each issue in search result
       const issueNum = issue.number
       const repoUrl = issue.repository_url
       console.log('issueNum', issueNum, repoUrl)
@@ -21,13 +31,20 @@ module.exports = ({ dependencies: { extractRepoDetails, getUserCommentedIssues, 
       total_user_comments += userComments.length
       console.log('userComments.length', userComments.length)
       // const commentBlob = "@itaditya I don't like the way you do things, your library is a joke"
-      const commentBlob = userComments.map(comment => comment.body).join('.\n')
+      let commentBlob = userComments.map(comment => comment.body).join('.\n')
+      if (commentBlob.length <= 0) continue // empty commentBlob
+      commentBlob = commentBlob.substr(0, 3000) // perspective api limits the text size to 3000B
       console.log('commentBlob', commentBlob)
-      if (commentBlob.length < 1 || commentBlob.length > 3000) continue // perspective api text limit 3000
       const toxicScore = await sentimentAnalyser(commentBlob)
       const isToxic = toxicScore >= 0.6
       context.log('toxicScore is', toxicScore)
-      break
+      if (isToxic) {
+        await createDiscussionIssue(context, {
+          username,
+          owner
+        })
+        break
+      }
     }
   }
 

--- a/lib/github-api/createDiscussionIssue.js
+++ b/lib/github-api/createDiscussionIssue.js
@@ -1,0 +1,9 @@
+module.exports = (context, { owner, username }) => {
+  return context.github.issues.create({
+    owner,
+    repo: 'maintainers-discussion',
+    title: `${username}-discussion`,
+    body: `@${username} has been found out to be hostile in the past.
+      This issue is opened so that maintainers can discuss about it.`
+  })
+}

--- a/lib/github-api/getUserDiscussionIssue.js
+++ b/lib/github-api/getUserDiscussionIssue.js
@@ -1,0 +1,5 @@
+module.exports = (context, { owner, username }) => {
+  return context.github.search.issues({
+    q: `repo:${owner}/maintainers-discussion is:issue in:title ${username}-discussion`
+  })
+}

--- a/test/backgroundFinder.test.js
+++ b/test/backgroundFinder.test.js
@@ -1,11 +1,15 @@
 const backgroundFinder = require('../lib/backgroundFinder')
 
 /* -- Mocks -- */
-const sentimentAnalyser = jest.fn().mockReturnValue(0.7)
 const extractRepoDetails = jest.fn().mockReturnValue({ owner: 'itaditya', repo: 'private-gh-app-test-repo' })
+const getUserDiscussionIssue = jest.fn().mockReturnValue({
+  data: {
+    total_count: 0
+  }
+})
 const getUserCommentedIssues = jest.fn().mockReturnValue({
   data: {
-    total_count: 2,
+    total_count: 1,
     items: [{
       number: 15,
       repository_url: 'https://api.github.com/repos/aps120797/playground'
@@ -21,25 +25,36 @@ const getCommentsOnIssue = jest.fn().mockReturnValue({
     }
   }]
 })
+const sentimentAnalyser = jest.fn().mockReturnValue(0.7)
+const createDiscussionIssue = jest.fn().mockReturnValue(Promise.resolve({
+  status: 200
+}))
 /* ^- Mocks -^ */
 
 const backgroundFinderInstance = backgroundFinder({
   dependencies: {
     extractRepoDetails,
+    getUserDiscussionIssue,
     getUserCommentedIssues,
     getCommentsOnIssue,
-    sentimentAnalyser
+    sentimentAnalyser,
+    createDiscussionIssue
   }
 })
 
 test('backgroundFinder is working', async () => {
   const context = {
-    payload: { comment: { user: { login: 'itaditya' } } },
+    payload: {
+      repository: { owner: { login: 'itaditya' } },
+      comment: { user: { login: 'itaditya' } }
+    },
     log: console.log
   }
   await backgroundFinderInstance(context)
   expect(extractRepoDetails).toHaveBeenCalled()
-  expect(sentimentAnalyser).toHaveBeenCalled()
+  expect(getUserDiscussionIssue).toHaveBeenCalled()
   expect(getUserCommentedIssues).toHaveBeenCalled()
   expect(getCommentsOnIssue).toHaveBeenCalled()
+  expect(sentimentAnalyser).toHaveBeenCalled()
+  expect(createDiscussionIssue).toHaveBeenCalled()
 })

--- a/test/sandboxes/backgroundFinder.sandbox.js
+++ b/test/sandboxes/backgroundFinder.sandbox.js
@@ -3,8 +3,10 @@ const request = require('superagent')
 
 const extractRepoDetails = require('../../lib/utils/extractRepoDetailsFromUrl')
 const analyseSentiment = require('../../lib/utils/analyseSentiment')
+const getUserDiscussionIssue = require('../../lib/github-api/getUserDiscussionIssue')
 const getUserCommentedIssues = require('../../lib/github-api/getUserCommentedIssues')
 const getCommentsOnIssue = require('../../lib/github-api/getCommentsOnIssue')
+const createDiscussionIssue = require('../../lib/github-api/createDiscussionIssue')
 
 const sentimentAnalyser = analyseSentiment(process.env.PERSPECTIVE_API_KEY, {
   dependencies: { request }
@@ -13,9 +15,11 @@ const sentimentAnalyser = analyseSentiment(process.env.PERSPECTIVE_API_KEY, {
 const backgroundFinder = require('../../lib/backgroundFinder')({
   dependencies: {
     extractRepoDetails,
+    getUserDiscussionIssue,
     getUserCommentedIssues,
     getCommentsOnIssue,
-    sentimentAnalyser
+    sentimentAnalyser,
+    createDiscussionIssue
   }
 })
 

--- a/test/sandboxes/createDiscussionIssue.sandbox.js
+++ b/test/sandboxes/createDiscussionIssue.sandbox.js
@@ -1,0 +1,9 @@
+const createDiscussionIssue = require('../../lib/github-api/createDiscussionIssue')
+
+module.exports = async context => {
+  const result = await createDiscussionIssue(context, {
+    owner: 'itaditya',
+    username: 'itaditya'
+  })
+  console.log(result);
+}

--- a/test/sandboxes/getCommentsOnIssue.sandbox.js
+++ b/test/sandboxes/getCommentsOnIssue.sandbox.js
@@ -3,9 +3,9 @@ const getCommentsOnIssue = require('../../lib/github-api/getCommentsOnIssue')
 module.exports = async context => {
   const result = await getCommentsOnIssue(context, {
     owner: 'itaditya',
-    repo: 'gh-app-test-repo',
-    issueNum: 1
+    repo: 'maintainers-discussion',
+    issueNum: 2
   })
   const { data: comments } = result
-  console.log('First Comment: \n', comments[0])
+  console.log('First Comment: \n', result)
 }


### PR DESCRIPTION
Algorithm -

* Check if issue for the user in **maintainers-discussion** repo is already opened or not.
* If issue exists, it means that the bot has already found the user to be hostile. In this case we don't do anything.
* Otherwise, we collect their public issues and using sentimentAnalysis find toxic comments.
* If found we open an issue titled **{username}-discussion**.