### PR TITLE
added is:open statement in search query which fixes #30

### DIFF
--- a/lib/github-api/getUserDiscussionIssue.js
+++ b/lib/github-api/getUserDiscussionIssue.js
@@ -1,5 +1,5 @@
 module.exports = (context, { owner, username }) => {
   return context.github.search.issues({
-    q: `repo:${owner}/maintainers-discussion is:issue in:title ${username}-discussion`
+    q: `repo:${owner}/maintainers-discussion is:issue is:open in:title ${username}-discussion`
   })
 }


### PR DESCRIPTION
In case of false positives, the maintainers can close the issue opened for a user in the maintainers-discussion repo. This PR limit the discussion issue search to open issues only.