### PR TITLE
handle case when totalUserComments more than 100 which fixes #36

### DIFF
--- a/lib/backgroundFinder.js
+++ b/lib/backgroundFinder.js
@@ -80,6 +80,11 @@ const backgroundFinderModule = ({ dependencies: { extractRepoDetails, getUserDis
         context.log(`${username}'s ${totalUserComments} comments were analysed`)
         break
       }
+
+      if (totalUserComments > 100) {
+        context.log(`More than 100 comments of ${username} have been analyzed & it is concluded that he is not hostile.`)
+        break
+      }
     }
   }
 


### PR DESCRIPTION
In case, more than 100 public comments of a user have been analysed and the `userToxicCommentsLimit` hasn't been exhausted then we stop the analysis and conclude that the user is not hostile