### PR TITLE
createDiscussionRepo github-api method created which fixes #56

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ LOG_LEVEL=debug
 # Go to https://smee.io/new set this to the URL that you are redirected to.
 # WEBHOOK_PROXY_URL=
 PERSPECTIVE_API_KEY=
+GITHUB_ACCESS_TOKEN=

--- a/lib/github-api/createDiscussionRepo.js
+++ b/lib/github-api/createDiscussionRepo.js
@@ -1,0 +1,17 @@
+/**
+ * createDiscussionRepo github-api method used to create a discussion repo for a user/org in probot-background-check org
+ * @param {object} github - authenticated github client
+ * @param {object} data
+ * @param {string} data.owner - name of user/org for whose repo's will be scanned for toxic users and their discussion will be held in owner-discussions repo.
+ * @returns {Promise<object>}
+ */
+
+module.exports = (github, { owner }) => {
+  return github.repos.createForOrg({
+    org: 'probot-background-check',
+    name: `${owner}-discussions`,
+    description: 'Repo to have discussions about toxic users',
+    // private: true,
+    auto_init: true
+  })
+}

--- a/lib/github-api/createDiscussionRepo.js
+++ b/lib/github-api/createDiscussionRepo.js
@@ -1,15 +1,15 @@
 /**
- * createDiscussionRepo github-api method used to create a discussion repo for a user/org in probot-background-check org
+ * createDiscussionRepo github-api method used to create a discussion repo named appInstallerName-discussions for a user/org in probot-background-check org in which discussion for users who have been hostile will be held.
  * @param {object} github - authenticated github client
  * @param {object} data
- * @param {string} data.owner - name of user/org for whose repo's will be scanned for toxic users and their discussion will be held in owner-discussions repo.
+ * @param {string} data.appInstallerName - name of user/org who installed the app.
  * @returns {Promise<object>}
  */
 
-module.exports = (github, { owner }) => {
+module.exports = (github, { appInstallerName }) => {
   return github.repos.createForOrg({
     org: 'probot-background-check',
-    name: `${owner}-discussions`,
+    name: `${appInstallerName}-discussions`,
     description: 'Repo to have discussions about toxic users',
     // private: true,
     auto_init: true

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "dependencies": {
-    "probot": "^6.0.0",
+    "probot": "6.2.1",
     "superagent": "^3.8.3"
   },
   "devDependencies": {

--- a/test/__snapshots__/createDiscussionRepo.test.js.snap
+++ b/test/__snapshots__/createDiscussionRepo.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createDiscussionRepo is working 1`] = `
+Array [
+  Array [
+    Object {
+      "auto_init": true,
+      "description": "Repo to have discussions about toxic users",
+      "name": "test-org-discussions",
+      "org": "probot-background-check",
+    },
+  ],
+]
+`;

--- a/test/createDiscussionRepo.test.js
+++ b/test/createDiscussionRepo.test.js
@@ -1,14 +1,22 @@
 const createDiscussionRepo = require('../lib/github-api/createDiscussionRepo')
 
 test('createDiscussionRepo is working', async () => {
-  const owner = 'test'
   const github = {
-    repos: {
-      createForOrg ({ org, name }) {
-        expect(org).toBe('probot-background-check')
-        expect(name).toBe(`${owner}-discussions`)
-      }
-    }
+    repos: { createForOrg: jest.fn() }
   }
-  await createDiscussionRepo(github, { owner })
+
+  // Call your function, which internally calls your above mock function
+  await createDiscussionRepo(github, { appInstallerName: 'test-org' })
+
+  // Test that your mock function has been called
+  expect(github.repos.createForOrg).toHaveBeenCalledWith({
+    org: 'probot-background-check',
+    name: 'test-org-discussions',
+    description: 'Repo to have discussions about toxic users',
+    // private: true,
+    auto_init: true
+  })
+
+  // Test that your mock function has been called with the right arguments
+  expect(github.repos.createForOrg.mock.calls).toMatchSnapshot()
 })

--- a/test/createDiscussionRepo.test.js
+++ b/test/createDiscussionRepo.test.js
@@ -1,0 +1,14 @@
+const createDiscussionRepo = require('../lib/github-api/createDiscussionRepo')
+
+test('createDiscussionRepo is working', async () => {
+  const owner = 'test'
+  const github = {
+    repos: {
+      createForOrg ({ org, name }) {
+        expect(org).toBe('probot-background-check')
+        expect(name).toBe(`${owner}-discussions`)
+      }
+    }
+  }
+  await createDiscussionRepo(github, { owner })
+})

--- a/test/sandboxes/createDiscussionRepo.sandbox.js
+++ b/test/sandboxes/createDiscussionRepo.sandbox.js
@@ -1,0 +1,14 @@
+require('dotenv').config({path: '../../.env'})
+const octokit = require('probot/lib/github')()
+
+const createDiscussionRepo = require('../../lib/github-api/createDiscussionRepo')
+
+module.exports = async context => {
+  octokit.authenticate({
+    type: 'token',
+    token: process.env.GITHUB_ACCESS_TOKEN
+  })
+  await createDiscussionRepo(octokit, {
+    owner: 'test-org'
+  })
+}

--- a/test/sandboxes/createDiscussionRepo.sandbox.js
+++ b/test/sandboxes/createDiscussionRepo.sandbox.js
@@ -9,6 +9,6 @@ module.exports = async context => {
     token: process.env.GITHUB_ACCESS_TOKEN
   })
   await createDiscussionRepo(octokit, {
-    owner: 'test-org'
+    appInstallerName: 'test-org'
   })
 }


### PR DESCRIPTION
This PR is to add a github-api method which when invoked creates a discussion repo on [`probot-backround-check`](https://github.com/probot-background-check) org.

### Use Case

When a person installs the app, we will create a repo in `probot-backround-check` (for now only until @JasonEtco provided a paid one) so that when the app find toxic users commenting in the person's repo, the app can create issue in the name of the toxic user in the person's repo. 

### Implementation

The github-api method accepts two params, one is `github` which is a authenticated github client used to make requests to github.

this github-api method is made such that it doesn't care how the github client was authenticated (via installation or via app or via personal token).

The second param is a data object with the owner field which should get the name of the person (individual or org) which installed the app.

Note - The sandbox file is used to run `createDiscussionRepo.js` for manually testing it independently (like a driver in bottom-up software development approach). It uses a personal access token from github to authenticate github client. This is because it was easier to provide org repo create scope to the github app this way.